### PR TITLE
Add history, and use yt-dlp for videos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 bs4
 argparse
+yt_dlp


### PR DESCRIPTION
Create history file to track completed files so that large albums can be downloaded over time
Handle videos using YT-DLP since it can resume interrupted downloads