### PR TITLE
Add logging of downloaded files

### DIFF
--- a/dump.py
+++ b/dump.py
@@ -24,9 +24,9 @@ def get_items_list(url, extensions, min_file_size, use_album_id, custom_path=Non
         json_data = json.loads(json_data_element.string)
         files = json_data['props']['pageProps']['album']['files'] if album_or_file == 'album' else [json_data['props']['pageProps']['file']]
         if album_or_file == 'file':
-            item_urls = [f"{file['mediafiles']}/{file['name']}" for file in files if int(file['size']) > (min_file_size * 1000)]
+            item_urls = [f"{file['mediafiles']}/{file['name']}" for file in files if int(float(file['size'])) > (min_file_size * 1000)]
         else:
-            item_urls = [f"{file['cdn'].replace('/cdn','/media-files')}/{file['name']}" for file in files if int(file['size']) > (min_file_size * 1000)]
+            item_urls = [f"{file['cdn'].replace('/cdn','/media-files')}/{file['name']}" for file in files if int(float(file['size'])) > (min_file_size * 1000)]
         album_name = json_data['props']['pageProps'][album_or_file]['name'] if not use_album_id else str(json_data['props']['pageProps'][album_or_file]['id'])
     else:
         items = soup.find_all('a', {'class': 'image'})

--- a/dump.py
+++ b/dump.py
@@ -6,8 +6,6 @@ import traceback
 import os
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse
-import yt_dlp as youtube_dl
-import mimetypes
 
 
 def get_items_list(url, extensions, min_file_size, use_album_id, custom_path=None):
@@ -72,17 +70,9 @@ def download(item_url, custom_path, album_name=None, is_bunkr=False):
     else:
         file_name = get_url_data(item_url)['file_name']
         with requests.get(item_url, headers={'Referer': 'https://stream.bunkr.is/'} if is_bunkr else {}, stream=True) as r:
-
-            # Use YT-DLP for videos since it can resume downloads
-            if 'video' in r.headers['Content-Type']:
-                dYdlOptions = dict()
-                dYdlOptions['outtmpl'] = rf'.\\{download_path}\\%(title).125s.%(ext)s'
-                with youtube_dl.YoutubeDL(dYdlOptions) as ydl:
-                    ydl.download([item_url])
-            else:
-                with open(os.path.join(download_path, file_name), 'wb') as f:
-                    for chunk in r.iter_content(chunk_size=8192):
-                        f.write(chunk)
+            with open(os.path.join(download_path, file_name), 'wb') as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
 
         # Write item to history when download is done
         with open(sHistoryFile, 'a') as history:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
 bs4
 argparse
-yt_dlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 bs4
 argparse
+yt_dlp


### PR DESCRIPTION
Add a history file that logs completed files to help download large albums. When resuming an album, items that have already been logged as completed will be skipped.