### PR TITLE
Fix for remove_illegal_chars

### DIFF
--- a/dump.py
+++ b/dump.py
@@ -140,7 +140,7 @@ def mark_as_downloaded(item_url, download_path):
     return
 
 def remove_illegal_chars(string):
-    return re.sub(r"[<>:/\\|?*\"]|[\0-\31]", "-", string)
+    return re.sub(r'[<>:"/\\|?*\']|[\0-\31]', "-", string).strip()
     
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(sys.argv[1:])


### PR DESCRIPTION
remove_illegal_chars was missing some illegal characters resulting in errors such as:
`FileNotFoundError: [Errno 2] No such file or directory: 'D:\\CyberdropBunkrDownloader\\downloads\\-            video 2-          \\already_downloaded.txt'`